### PR TITLE
Update build instructions, move bootstrap -> autogen.sh

### DIFF
--- a/README.org
+++ b/README.org
@@ -20,24 +20,35 @@
    Authinfo follows usual GNU Autotools build procedure:
 
    #+BEGIN_SRC sh
-   ./configure
-   make all install
+   # Only required if you're missing ./configure (e.g. you're building from git)
+   $ ./autogen.sh
+
+   # Check build deps and configure the project.
+   $ ./configure
+
+   # Compile and install everything.
+   $ make all install
    #+END_SRC
 
-   Optional features:
+   If you encounter an error about undefined macro =AM_PATH_GPGME_PTHREAD= when
+   running =./autogen.sh= you will need to install the =libgpgme= autoconf
+   macros. On Ubuntu/Debian install the =libgpgme-dev= package, on Fedora or
+   other RPM based distros install the =gpgme-devel= package.
+
+*** Optional features:
      - GPG support (default is on)
 
-       To disable pass --disable-gpg flag to configure script. When enabled,
+       To disable pass =--disable-gpg= flag to configure script. When enabled,
        [[http://www.gnupg.org/related_software/gpgme/][GPGME]] must be installed in the system.
 
      - Python2 bindings (default is on)
 
-       To disable pass --disable-python flag to configure script. Minimal
+       To disable pass =--disable-python= flag to configure script. Minimal
        supported python version is 2.5. Python3 is not supported.
 
      - CLI tool (default is on)
 
-       To disable pass --disable-cli flag to configure script.
+       To disable pass =--disable-cli= flag to configure script.
 
 * Using it
 ** Password file


### PR DESCRIPTION
I renamed `bootstrap` to `autogen.sh` since that's kind of a de facto standard name for this script. I also updated the README to explain that running this command is necessary (as the configure script is not checked in).

There's also a rather confusing error message when running `autogen.sh` if you are missing the libgpgme autotools macros, which looks like this:

```
configure.ac:59: warning: macro 'AM_PATH_GPGME_PTHREAD' not found in library
libtoolize: putting auxiliary files in '.'.
libtoolize: copying file './ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
configure.ac:59: warning: macro 'AM_PATH_GPGME_PTHREAD' not found in library
configure.ac:59: error: possibly undefined macro: AM_PATH_GPGME_PTHREAD
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: /usr/bin/autoconf failed with exit status: 1
```

I've added a note in the README explaining what to do if users encounter this issue. You can see how the final thing renders on GitHub at: https://github.com/eklitzke/authinfo/tree/autogen.sh